### PR TITLE
Set longer timeouts

### DIFF
--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -9,6 +9,8 @@ akka {
 api {
   port = 9000
   port = ${?SERVER_PORT}
+  actor-timeout = 60s
+  actor-timeout = ${?ACTOR_TIMEOUT}
 }
 
 kafka {
@@ -37,8 +39,10 @@ api-dispatcher {
 akka {
   http {
     server {
-      request-timeout = infinite
-      idle-timeout = infinite
+      request-timeout = 60s
+      request-timeout = ${?AKKA_HTTP_SERVER_REQUEST_TIMEOUT}
+      idle-timeout = 60s
+      idle-timeout = ${?AKKA_HTTP_SERVER_IDLE_TIMEOUT}
     }
   }
 }

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -33,3 +33,12 @@ api-dispatcher {
     fixed-pool-size = 9
   }
 }
+
+akka {
+  http {
+    server {
+      request-timeout = infinite
+      idle-timeout = infinite
+    }
+  }
+}

--- a/src/main/scala/Api.scala
+++ b/src/main/scala/Api.scala
@@ -36,9 +36,10 @@ class Api(kafkaClientActorRef: ActorRef)
         }
     }
 
-  implicit val duration: Timeout = 300.seconds
-
   val settings = ApiSettings(actorSystem.settings.config)
+
+  implicit val duration: Timeout = settings.timeout
+
 
   val mapper = new ObjectMapper()
   mapper.registerModule(new MetricsModule(TimeUnit.SECONDS, TimeUnit.MILLISECONDS, false))
@@ -91,8 +92,11 @@ object Api {
     new Api(kafkaClientActorRef)
 }
 
-case class ApiSettings(port: Int)
+case class ApiSettings(port: Int, timeout: Timeout)
 
 object ApiSettings {
-  def apply(config: Config): ApiSettings = ApiSettings(config.getInt("api.port"))
+  def apply(config: Config): ApiSettings = ApiSettings(
+    config.getInt("api.port"),
+    Timeout(Duration.fromNanos(config.getDuration("api.actor-timeout").getNano))
+  )
 }

--- a/src/main/scala/Api.scala
+++ b/src/main/scala/Api.scala
@@ -36,7 +36,7 @@ class Api(kafkaClientActorRef: ActorRef)
         }
     }
 
-  implicit val duration: Timeout = 60.seconds
+  implicit val duration: Timeout = 300.seconds
 
   val settings = ApiSettings(actorSystem.settings.config)
 


### PR DESCRIPTION
Running against a large consumer group (multiple topics each with 96 partitions)
I hit timeout issues.

Upping the request, idle and actor ask timeout as a workaround.

note: the kafka CLI utils take a long time to respond too.

Signed-off-by: Ian Duffy <ian.duffy@zalando.ie>