### PR TITLE
Generate scm-source as part of docker build

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -23,7 +23,8 @@ lazy val root = (project in file("."))
   .settings(gitSettings)
   .enablePlugins(
     GitVersioning,
-    JavaServerAppPackaging
+    JavaServerAppPackaging,
+    ScmSourcePlugin
   )
 
 libraryDependencies ++= Seq(

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,3 +1,6 @@
-addSbtPlugin("com.eed3si9n"     % "sbt-assembly"        % "0.14.3")
-addSbtPlugin("com.typesafe.sbt" % "sbt-git"             % "0.8.5")
-addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.1.5")
+resolvers += Resolver.url("sbt-plugins", url("https://dl.bintray.com/zalando/sbt-plugins/"))(Resolver.ivyStylePatterns)
+
+addSbtPlugin("com.eed3si9n"       % "sbt-assembly"        % "0.14.3")
+addSbtPlugin("com.typesafe.sbt"   % "sbt-git"             % "0.8.5")
+addSbtPlugin("com.typesafe.sbt"   % "sbt-native-packager" % "1.1.5")
+addSbtPlugin("ie.zalando.buffalo" % "sbt-scm-source"    % "0.0.5")


### PR DESCRIPTION
For compliance purposes internally we should have an scm-source
in the root of the image otherwise we get violations.

Adding in sbt-scm-source in order to take care of this.

Signed-off-by: Ian Duffy <ian@ianduffy.ie>