### PR TITLE
Add instructions for using the docker images.

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ They can be used as follows:
 docker run -it --rm -p 9000:9000 -e KAFKA_ENDPOINT=127.0.0.1:9092 zalandoremora/remora:0.2.0
 ```
 
+For further examples see the [docker-compose.yml](docker-compose/docker-compose.yml)
+
 ## Build
 
 * `sbt package`

--- a/README.md
+++ b/README.md
@@ -16,6 +16,16 @@ All we did was wrap and hack the [kafka consumer group command](https://github.c
 * 2.11.8
 * Store offsets in kafka
 
+## Running
+
+Images for all versions are available on [Docker Hub](https://hub.docker.com/r/zalandoremora/remora/tags/)
+
+They can be used as follows:
+
+```
+docker run -it --rm -p 9000:9000 -e KAFKA_ENDPOINT=127.0.0.1:9092 zalandoremora/remora:0.2.0
+```
+
 ## Build
 
 * `sbt package`

--- a/docker-compose/docker-compose.yml
+++ b/docker-compose/docker-compose.yml
@@ -4,7 +4,7 @@ services:
     image: wurstmeister/zookeeper
 
   kafka:
-    image: wurstmeister/kafka:0.10.0.1
+    image: wurstmeister/kafka:0.10.2.1
     hostname: kafka
     environment:
       KAFKA_ADVERTISED_HOST_NAME: kafka
@@ -16,14 +16,13 @@ services:
       - "2181:2181"
 
   remora:
-#    build: ./target/docker/.
-    image: pierone.stups.zalan.do/setanta/remora:0.0.6-2-ge24db20
+    image: zalandoremora/remora:0.2.0
     depends_on:
       - kafka
     hostname: remora
     environment:
       KAFKA_ENDPOINT: "kafka:9092"
-#      JAVA_OPTS:               >
+#      JAVA_OPTS:
 #        -Xmx1g
 #        -Dcom.sun.management.jmxremote.rmi.port=9090
 #        -Dcom.sun.management.jmxremote=true


### PR DESCRIPTION
Docker images for both 0.1.0 and 0.2.0 have been pushed to docker hub.
https://hub.docker.com/r/zalandoremora/remora/

Updated the readme to include a docker run command.

Signed-off-by: Ian Duffy <ian.duffy@zalando.ie>