### PR TITLE
Cache dependencies on travis to save time.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,3 +3,13 @@ scala:
  - 2.11.8
 jdk:
   - oraclejdk8
+sudo: false
+before_cache:
+  # Cleanup the cached directories to avoid unnecessary cache updates
+  - find $HOME/.ivy2/cache -name "ivydata-*.properties" -print -delete
+  - find $HOME/.sbt        -name "*.lock"               -print -delete
+cache:
+  directories:
+    - $HOME/.ivy2/cache
+    - $HOME/.sbt
+


### PR DESCRIPTION
Last PR for awhile @marky-mark 

Speeding up the travis-ci feedback for PRs by caching dependencies. Takes off roughly a minute on the build time.

Signed-off-by: Ian Duffy <ian.duffy@zalando.ie>