### PR TITLE
permit sbt assembly by excluding kafka's slf4j

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -40,7 +40,7 @@ libraryDependencies ++= Seq(
   "org.apache.httpcomponents" %  "httpclient"                   % "4.5.2",
   "org.scalaz"                %% "scalaz-core"                  % "7.2.8",
   "com.typesafe.play"         %% "play-json"                    % "2.4.8",
-  "org.apache.kafka"          %% "kafka"                        % "0.10.2.1",
+  "org.apache.kafka"          %% "kafka"                        % "0.10.2.1" exclude("org.slf4j", "slf4j-log4j12"),
   "com.typesafe.akka"         %% "akka-http-testkit"            % "10.0.5"  % "test",
   "org.scalatest"             %% "scalatest"                    % "2.2.4"   % "test",
   "org.scalamock"             %% "scalamock-scalatest-support"  % "3.2"     % "test",


### PR DESCRIPTION
Assembly isn't working with two versions of slf4j being imported. Exclude kafka's on import.