### PR TITLE
Add a delivery.yaml for automated docker image builds

### DIFF
--- a/.zappr.yaml
+++ b/.zappr.yaml
@@ -6,4 +6,4 @@ approvals:
         orgs:
           - "zalando"
 
-X-Zalando-Team: "dougal"
+X-Zalando-Team: dougal

--- a/delivery.yaml
+++ b/delivery.yaml
@@ -1,0 +1,19 @@
+
+build_steps:
+- desc: Install docker
+  cmd: |
+    apt-get update
+    apt-get install -y apt-transport-https ca-certificates curl software-properties-common
+    curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
+    add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) edge"
+    apt-get update
+    apt-get install -y docker-ce
+- desc: Install sbt and java
+  cmd: |
+    echo "deb http://dl.bintray.com/sbt/debian /" | tee -a /etc/apt/sources.list.d/sbt.list
+    apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 642AC823
+    apt-get update
+    apt-get install -y sbt=0.13.8 openjdk-8-jdk
+- desc: Build and push docker image
+  cmd: |
+    sbt docker:publish -Ddocker.repo=registry-write.opensource.zalan.do/dougal


### PR DESCRIPTION
This PR adds a delivery.yaml file, this file will be used by CDP
to automatically build and push a docker image to registry.opensource.zalan.do/dougal/remora

Given this, we can get rid of the dockerhub image and an external collaborator can trigger a release
by merging to master.

Signed-off-by: Ian Duffy <ian.duffy@zalando.ie>