### PR TITLE
Adds datadog tags to metrics in order to facilitate dashboard management

### DIFF
--- a/src/main/scala/Api.scala
+++ b/src/main/scala/Api.scala
@@ -7,7 +7,7 @@ import akka.http.scaladsl.Http
 import akka.http.scaladsl.marshalling._
 import akka.http.scaladsl.model.{HttpResponse, MediaTypes, StatusCodes}
 import akka.http.scaladsl.server.Directives._
-import akka.http.scaladsl.server.{StandardRoute, ExceptionHandler}
+import akka.http.scaladsl.server.{ExceptionHandler, StandardRoute}
 import akka.pattern.ask
 import akka.stream.ActorMaterializer
 import akka.util.Timeout
@@ -17,6 +17,7 @@ import com.codahale.metrics.json.MetricsModule
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.typesafe.config.Config
 import de.heikoseeberger.akkahttpplayjson.PlayJsonSupport
+import models.{GroupInfo, Health}
 import play.api.libs.json._
 
 import scala.concurrent.duration._

--- a/src/main/scala/JsonOps.scala
+++ b/src/main/scala/JsonOps.scala
@@ -1,3 +1,4 @@
+import models.{GroupInfo, Node, PartitionAssignmentState}
 import play.api.libs.functional.syntax._
 import play.api.libs.json._
 

--- a/src/main/scala/Models.scala
+++ b/src/main/scala/Models.scala
@@ -1,15 +1,46 @@
 
+package object models {
 
-case class Health(healthy: Boolean, message: String, error: Option[Throwable])
+  case class Health(healthy: Boolean, message: String, error: Option[Throwable])
 
-case class GroupInfo(state: Option[String] = None, partitionAssignmentStates: Option[Seq[PartitionAssignmentState]] = None, lagPerTopic: Option[Map[String, Long]] = None)
+  case class GroupInfo(state: Option[String] = None, partitionAssignmentStates: Option[Seq[PartitionAssignmentState]] = None, lagPerTopic: Option[Map[String, Long]] = None)
 
-case class Node(id: Option[Int] = None, idString: Option[String] = None, host: Option[String] = None, port: Option[Int] = None, rack: Option[String] = None)
+  case class Node(id: Option[Int] = None, idString: Option[String] = None, host: Option[String] = None, port: Option[Int] = None, rack: Option[String] = None)
 
-//This is a copy of the object inside the KafkaConsumerGroupService which is protected
-case class PartitionAssignmentState(group: String, coordinator: Option[Node] = None, topic: Option[String] = None,
-                                    partition: Option[Int] = None, offset: Option[Long] = None, lag: Option[Long] = None,
-                                    consumerId: Option[String] = None, host: Option[String] = None,
-                                    clientId: Option[String] = None, logEndOffset: Option[Long] = None)
+  //This is a copy of the object inside the KafkaConsumerGroupService which is protected
+  case class PartitionAssignmentState(group: String, coordinator: Option[Node] = None, topic: Option[String] = None,
+                                      partition: Option[Int] = None, offset: Option[Long] = None, lag: Option[Long] = None,
+                                      consumerId: Option[String] = None, host: Option[String] = None,
+                                      clientId: Option[String] = None, logEndOffset: Option[Long] = None)
 
 
+  case class RegistryKafkaMetric(prefix: String, topic: String, partition: Option[String], group: String, suffix: String)
+
+  object RegistryKafkaMetric {
+
+    val metricRegex = "(.+)\\.(.+)\\.(.+)\\.(.+)\\.(.+)".r
+    val metricWithoutPartitionRegex = "(.+)\\.(.+)\\.(.+)\\.(.+)".r
+
+    def encode(metric: RegistryKafkaMetric): String = metric.partition match {
+      case Some(partition) => s"${removeDots(metric.prefix)}." +
+        s"${removeDots(metric.topic)}." +
+        s"${removeDots(partition)}." +
+        s"${removeDots(metric.group)}." +
+        s"${removeDots(metric.suffix)}"
+      case None => s"${removeDots(metric.prefix)}" +
+        s".${removeDots(metric.topic)}" +
+        s".${removeDots(metric.group)}" +
+        s".${removeDots(metric.suffix)}"
+    }
+
+    private def removeDots(s: String) = s.replaceAll("\\.", "_")
+
+    def decode(metricName: String): Option[RegistryKafkaMetric] = metricName match {
+      case metricRegex(prefix, topic, partition, group, suffix) => Some(RegistryKafkaMetric(prefix, topic, Some(partition), group, suffix))
+      case metricWithoutPartitionRegex(prefix, topic, group, suffix) => Some(RegistryKafkaMetric(prefix, topic, None, group, suffix))
+      case _ => None
+    }
+
+  }
+
+}

--- a/src/main/scala/RemoraKafkaConsumerGroupService.scala
+++ b/src/main/scala/RemoraKafkaConsumerGroupService.scala
@@ -3,6 +3,7 @@ import java.util.logging.Logger
 import config.KafkaSettings
 import kafka.admin.ConsumerGroupCommand
 import kafka.admin.ConsumerGroupCommand.{ConsumerGroupCommandOptions, KafkaConsumerGroupService}
+import models.{GroupInfo, Node, PartitionAssignmentState}
 
 import scala.concurrent.{ExecutionContextExecutor, Future}
 

--- a/src/test/scala/ModelsSpec.scala
+++ b/src/test/scala/ModelsSpec.scala
@@ -1,0 +1,35 @@
+import models.RegistryKafkaMetric
+import org.scalamock.scalatest.MockFactory
+import org.scalatest.{FlatSpec, Matchers}
+
+class ModelsSpec extends FlatSpec with Matchers with MockFactory {
+
+  "RegistryKafkaMetric" should "be encoded as a string as expected with partition" in {
+    val metric = RegistryKafkaMetric("gauge","topic", Some("partition"), "group","lag")
+    RegistryKafkaMetric.encode(metric) should be("gauge.topic.partition.group.lag")
+  }
+
+  it should "be decoded from string without partition" in {
+    val stringMetric = "gauge.topic.group.lag"
+    RegistryKafkaMetric.decode(stringMetric) should be(Some(RegistryKafkaMetric("gauge","topic", None,"group","lag")))
+  }
+
+  it should "be encoded as a string as expected without partition" in {
+    val metric = RegistryKafkaMetric("gauge","topic", None, "group","lag")
+    RegistryKafkaMetric.encode(metric) should be("gauge.topic.group.lag")
+  }
+
+  it should "be decoded from string with partition" in {
+    val stringMetric = "gauge.topic.partition.group.lag"
+    RegistryKafkaMetric.decode(stringMetric) should be(Some(RegistryKafkaMetric("gauge","topic", Some("partition"),"group","lag")))
+  }
+
+
+
+  it should "return None if metric name is not standard" in {
+    val stringMetric = "gauge.faulty"
+    RegistryKafkaMetric.decode(stringMetric) should be(None)
+  }
+
+
+}


### PR DESCRIPTION
In order to be able to parse dynamically the kafka metrics sent to datadog,
their name had to be changed in order to use '.' as a delimiter between the different
metric component (e.g topic, group, partition).

Fixes #34