### PR TITLE
Support for brokers which require authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ docker run -it --rm -p 9000:9000 -e KAFKA_ENDPOINT=127.0.0.1:9092 registry.opens
 
 For further examples see the [docker-compose.yml](docker-compose/docker-compose.yml)
 
+For examples with broker authentication see the [docker-compose.yml](auth-example/docker-compose.yml)
+
 ### Usage
 
 #### Show active consumers 

--- a/auth-example/auth.properties
+++ b/auth-example/auth.properties
@@ -1,0 +1,3 @@
+security.protocol=SASL_PLAINTEXT
+sasl.mechanism=PLAIN
+sasl.jaas.config=org.apache.kafka.common.security.plain.PlainLoginModule required username="my-user" password="my-password";

--- a/auth-example/docker-compose.yml
+++ b/auth-example/docker-compose.yml
@@ -1,0 +1,35 @@
+version: '3'
+services:
+  zookeeper:
+    image: 'bitnami/zookeeper:latest'
+    environment:
+      - ALLOW_ANONYMOUS_LOGIN=yes
+    ports:
+     - '2181:2181'
+
+  kafka:
+    image: 'bitnami/kafka:latest'
+    depends_on:
+      - zookeeper
+    environment:
+      - KAFKA_ZOOKEEPER_CONNECT=zookeeper:2181
+      - ALLOW_PLAINTEXT_LISTENER=yes
+      - KAFKA_LISTENERS=SASL_PLAINTEXT://:9092
+      - KAFKA_ADVERTISED_LISTENERS=SASL_PLAINTEXT://localhost:9092
+      - KAFKA_BROKER_USER=my-user
+      - KAFKA_BROKER_PASSWORD=my-password
+    ports:
+      - '9092:9092'
+
+  remora:
+    image: registry.opensource.zalan.do/machina/remora
+    depends_on:
+      - kafka
+    hostname: remora
+    volumes:
+      - ./auth.properties:/auth.properties
+    environment:
+      KAFKA_ENDPOINT: "kafka:9092"
+      KAFKA_COMMAND_CONFIG: "/auth.properties"
+    ports:
+      - "9000:9000"

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -16,6 +16,10 @@ api {
 kafka {
   endpoint = "localhost:9092"
   endpoint = ${?KAFKA_ENDPOINT}
+  command {
+    config = ""
+    config = ${?KAFKA_COMMAND_CONFIG}
+  }
 }
 
 kafka-consumer-dispatcher {

--- a/src/main/scala/config/KafkaSettings.scala
+++ b/src/main/scala/config/KafkaSettings.scala
@@ -2,9 +2,12 @@ package config
 
 import com.typesafe.config.Config
 
-case class KafkaSettings(address: String)
+case class KafkaSettings(address: String, commandConfig: String)
 
 object KafkaSettings {
   def apply(config: Config): KafkaSettings =
-    KafkaSettings(config.getString("kafka.endpoint"))
+    KafkaSettings(
+      config.getString("kafka.endpoint"),
+      config.getString("kafka.command.config")
+    )
 }


### PR DESCRIPTION
Simple extension to enable additional config (for example SASL_PLAINTEXT or SASL_SSH auth).

Unfortunately I do not have a good idea how to add some integration tests here, so any suggestions are  welcome. 
I have only added some docker-compose example. 