### PR TITLE
Limit AWS SDK to only Cloudwatch

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -43,7 +43,7 @@ libraryDependencies ++= Seq(
   "com.blacklocus" % "metrics-cloudwatch" % "0.4.0",
   "org.coursera" % "dropwizard-metrics-datadog" % "1.1.13",
   "backline" %% "akka-http-metrics" % "1.0.0",
-  "com.amazonaws" % "aws-java-sdk" % "1.11.189",
+  "com.amazonaws" % "aws-java-sdk-cloudwatch" % "1.11.189",
   "com.typesafe.scala-logging" %% "scala-logging" % "3.7.2",
   "com.typesafe.akka" %% "akka-actor" % "2.4.17",
   "com.typesafe.akka" %% "akka-http" % "10.0.5",


### PR DESCRIPTION
This repo doesn't need Kinesis, S3, DynamoDB, etc., etc. dependencies. 

The DropWizard metrics dependency that you're including [doesn't either](https://github.com/blacklocus/metrics-cloudwatch/blob/master/build.gradle#L67)