### PR TITLE
Change to Trusty instead of Xenial (default) 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: trusty
 language: scala
 scala:
  - 2.11.8


### PR DESCRIPTION
Trying to fix JDK installation