### PR TITLE
Remove non-zalando employees from maintainers file

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -1,6 +1,2 @@
-Mark Kelly <mkelly28@tcd.ie>
-Adam Drakeford <adamdrakeford@gmail.com>
-Ian Duffy <ian@ianduffy.ie>
 Brendan Maguire <maguire.brendan@gmail.com>
-Leopoldo Muller <leopoldo.muller@gmail.com>
 Michal Michalski <regis86@gmail.com>


### PR DESCRIPTION
There is no point in listing non-zalando employees in the maintainer file, we have zero permissions to take any actions on PRs :(