### PR TITLE
Allow configuration of AdminClient in KafkaSettings

### DIFF
--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -20,6 +20,7 @@ kafka {
     config = ""
     config = ${?KAFKA_COMMAND_CONFIG}
   }
+  admin-client {}
 }
 
 kafka-consumer-dispatcher {

--- a/src/main/scala/config/KafkaSettings.scala
+++ b/src/main/scala/config/KafkaSettings.scala
@@ -1,21 +1,28 @@
 package config
 
-import scala.collection.Map
 import scala.collection.JavaConverters._
 import com.typesafe.config.Config
 import org.apache.kafka.clients.CommonClientConfigs
 import org.apache.kafka.clients.admin.AdminClient
 
-case class KafkaSettings(address: String, commandConfig: String) {
-  lazy val adminClient: AdminClient = AdminClient.create(Map[String, AnyRef](
-    CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG -> address
-  ).asJava)
+case class KafkaSettings(address: String, commandConfig: String, adminClientProps: java.util.Properties) {
+  lazy val adminClient: AdminClient = AdminClient.create(adminClientProps)
 }
 
 object KafkaSettings {
-  def apply(config: Config): KafkaSettings =
+  def apply(config: Config): KafkaSettings = {
+    val properties = new java.util.Properties()
+    val adminClientConfig = config.getConfig("kafka.admin-client")
+      .withValue(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG, config.getValue("kafka.endpoint"))
+
+    org.apache.kafka.clients.admin.AdminClientConfig.configNames().asScala.foreach {
+      k => if (adminClientConfig.hasPath(k)) properties.put(k, adminClientConfig.getAnyRef(k))
+    }
+
     KafkaSettings(
       config.getString("kafka.endpoint"),
-      config.getString("kafka.command.config")
+      config.getString("kafka.command.config"),
+      properties
     )
+  }
 }

--- a/src/test/resources/kafka-with-admin-client.conf
+++ b/src/test/resources/kafka-with-admin-client.conf
@@ -1,0 +1,9 @@
+kafka {
+  endpoint = "localhost:9092"
+  command {
+    config = "test.properties"
+  }
+  admin-client {
+    security.protocol = "SSL"
+  }
+}

--- a/src/test/resources/kafka-without-admin-client.conf
+++ b/src/test/resources/kafka-without-admin-client.conf
@@ -1,0 +1,7 @@
+kafka {
+  endpoint = "localhost:9092"
+  command {
+    config = "test.properties"
+  }
+  admin-client {}
+}

--- a/src/test/scala/config/KafkaSettingsSpec.scala
+++ b/src/test/scala/config/KafkaSettingsSpec.scala
@@ -1,0 +1,29 @@
+package config
+
+import com.typesafe.config.ConfigFactory
+import org.apache.kafka.clients.CommonClientConfigs
+import org.apache.kafka.clients.admin.AdminClientConfig
+import org.scalatest.{FlatSpec, Matchers}
+
+class KafkaSettingsSpec extends FlatSpec with Matchers {
+  "KafkaSettingsSpec" should "correctly inject the correct endpoint in AdminClient properties" in {
+    val conf = ConfigFactory.load("kafka-without-admin-client.conf")
+    val settings = KafkaSettings(conf)
+
+    settings.address should ===("localhost:9092")
+    settings.commandConfig should ===("test.properties")
+    settings.adminClientProps.get(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG) should ===("localhost:9092")
+  }
+
+  it should "correctly parse the correct security protocol if provided in AdminClient properties" in {
+    val conf = ConfigFactory.load("kafka-without-admin-client.conf")
+    val settings = KafkaSettings(conf)
+    val adminClientConfig = new AdminClientConfig(settings.adminClientProps)
+    adminClientConfig.getString(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG) should ===(CommonClientConfigs.DEFAULT_SECURITY_PROTOCOL)
+
+    val conf2 = ConfigFactory.load("kafka-with-admin-client.conf")
+    val settings2 = KafkaSettings(conf2)
+    val adminClientConfig2 = new AdminClientConfig(settings2.adminClientProps)
+    adminClientConfig2.getString(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG) should ===("SSL")
+  }
+}


### PR DESCRIPTION
Allow configuration of `AdminClient` generated in `KafkaSettings`, primarily to allow specifying SSL security protocol when running `DescribeCluster`. Introduces a new `kafka.admin-client` configuration object that allows full configuration of the generated `AdminClient` (although `bootstrap.servers` will continue to be injected as before).

Alternative approaches considered:
- allowing specifying `AdminClient`-specific or universal security protocol as a dedicated configuration entry (rejected as this would not scale well if more configuration options are needed in the future)
- allow specifying a path to an `AdminClient` configuration file similar to the existing `kafka.command.config` field (rejected as Kafka natively supports this in the existing case, but it doesn't support this for `AdminClient` so it would potentially be a lot of work to implement)