### PR TITLE
Refactor CloudWatch reporting by adding dedicated reporter class

### DIFF
--- a/src/main/scala/reporter/RemoraCloudWatchReporter.scala
+++ b/src/main/scala/reporter/RemoraCloudWatchReporter.scala
@@ -1,0 +1,23 @@
+package reporter
+
+import com.amazonaws.services.cloudwatch.{AmazonCloudWatchAsync, AmazonCloudWatchAsyncClientBuilder}
+import com.blacklocus.metrics.CloudWatchReporterBuilder
+import com.codahale.metrics.MetricRegistry
+import config.CloudWatch
+import filter.CloudWatchMetricFilter
+
+import java.util.concurrent.TimeUnit
+
+class RemoraCloudWatchReporter(metricRegistry: MetricRegistry, cloudWatchConfig: CloudWatch) {
+  val amazonCloudWatchAsync: AmazonCloudWatchAsync = AmazonCloudWatchAsyncClientBuilder.defaultClient
+
+  val logMetricFilter = new CloudWatchMetricFilter(cloudWatchConfig.metricFilter)
+
+  def startReporter(): Unit = new CloudWatchReporterBuilder()
+    .withNamespace(cloudWatchConfig.name)
+    .withRegistry(metricRegistry)
+    .withClient(amazonCloudWatchAsync)
+    .withFilter(logMetricFilter)
+    .build()
+    .start(cloudWatchConfig.intervalMinutes, TimeUnit.MINUTES)
+}


### PR DESCRIPTION
## Motivation

Refactor CloudWatch reporting code to make it easier to migrate off current library used for pushing metrics to CloudWatch (as the library is no longer maintained)

## Changes

- Introduce dedicated `RemoraCloudWatchReporter` class (similar to existing `RemoraDatadogReporter` class) to make it easier to replace `com.blacklocus metrics-cloudwatch` when updating SBT / Scala versions