### PR TITLE
Update github action dependencies

### DIFF
--- a/.github/workflows/scala.yml
+++ b/.github/workflows/scala.yml
@@ -18,10 +18,11 @@ jobs:
     - uses: actions/checkout@v2
     - uses: coursier/cache-action@v6
     - name: Setup Scala
-      uses: coursier/setup-action@v1
+      uses: actions/setup-java@v3
       with:
-        jvm: openjdk:17
-        apps: sbtn
+        distribution: 'temurin'
+        java-version: '17'
+        cache: 'sbt'
 
     - name: Run tests
       run: sbt test


### PR DESCRIPTION
The GithubAction dependencies are out of date.
I followed the instructions from [here](https://github.com/actions/setup-java#caching-sbt-dependencies).